### PR TITLE
add dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ einops
 timm
 xformers
 sentencepiece
+decord


### PR DESCRIPTION
when I tried the inference example, I found that one dependency is missing in the requirements.txt, which is `decord`, so I added it.